### PR TITLE
Pass empty command line arguments to the custom binary.

### DIFF
--- a/Config/Dyre/Options.hs
+++ b/Config/Dyre/Options.hs
@@ -106,13 +106,13 @@ customOptions otherArgs = do
                      Nothing -> getArgs
                      Just oa -> return oa
     -- Combine the other arguments with the Dyre-specific ones
-    let args = filter (not . null) $
-            mainArgs ++ [ if debugMode then "--dyre-debug" else ""
-                        , case stateFile of
-                               Nothing -> ""
-                               Just sf -> "--dyre-state-persist=" ++ sf
-                        , "--dyre-master-binary=" ++ fromJust masterPath
-                        ]
+    let args = mainArgs ++ (filter (not . null) $
+            [ if debugMode then "--dyre-debug" else ""
+            , case stateFile of
+                   Nothing -> ""
+                   Just sf -> "--dyre-state-persist=" ++ sf
+            , "--dyre-master-binary=" ++ fromJust masterPath
+            ])
     return args
 
 -- | Look for the given flag in the argument array, and store


### PR DESCRIPTION
This way empty arguments aren't lost and may be handled by the custom binary to allow proper parsing.
