### PR TITLE
Made compatible with unix >= 2.7

### DIFF
--- a/Config/Dyre/Compat.hs
+++ b/Config/Dyre/Compat.hs
@@ -74,7 +74,11 @@ customExec binary mArgs = do
         case childStatus of
              Nothing -> error "executeFile: couldn't get child process status"
              Just (Exited code) -> exitImmediately code
+#if MIN_VERSION_unix(2,7,0)
+             Just (Terminated _ _) -> exitImmediately ExitSuccess
+#else
              Just (Terminated _) -> exitImmediately ExitSuccess
+#endif
              Just (Stopped _) -> raiseSignal sigTSTP
   where forever a = a >> forever a
 

--- a/dyre.cabal
+++ b/dyre.cabal
@@ -1,5 +1,5 @@
 name:          dyre
-version:       0.8.11
+version:       0.8.12
 category:      Development, Configuration
 synopsis:      Dynamic reconfiguration in Haskell
 


### PR DESCRIPTION
..simply using a CPP ifdef.

I have also bumped the cabal manifest version, amend if not ok.

PR is obviously backward compatible with unix < 2.6

Alfredo
