### PR TITLE
use ghc from PATH instead of hardcoded one

### DIFF
--- a/Config/Dyre/Compile.hs
+++ b/Config/Dyre/Compile.hs
@@ -11,7 +11,6 @@ import System.FilePath   ( (</>) )
 import System.Directory  ( getCurrentDirectory, doesFileExist
                          , createDirectoryIfMissing )
 import Control.Exception ( bracket )
-import GHC.Paths         ( ghc )
 
 import Config.Dyre.Paths  ( getPaths )
 import Config.Dyre.Params ( Params(..) )
@@ -47,7 +46,7 @@ customCompile params@Params{statusOut = output} = do
     errFile <- getErrorPath params
     result <- bracket (openFile errFile WriteMode) hClose $ \errHandle -> do
         ghcOpts <- makeFlags params configFile tempBinary cacheDir libsDir
-        ghcProc <- runProcess ghc ghcOpts (Just cacheDir) Nothing
+        ghcProc <- runProcess "ghc" ghcOpts (Just cacheDir) Nothing
                               Nothing Nothing (Just errHandle)
         waitForProcess ghcProc
 

--- a/dyre.cabal
+++ b/dyre.cabal
@@ -42,7 +42,7 @@ library
                    Config.Dyre.Compile,
                    Config.Dyre.Relaunch
   build-depends:   base >= 4 && < 5, process, filepath,
-                   directory, ghc-paths, time, binary,
+                   directory, time, binary,
                    executable-path, xdg-basedir, io-storage
 
   if os(windows)


### PR DESCRIPTION
See this https://github.com/simonmar/ghc-paths/issues/4
I'm using `NixOS`, and it manipulates `$PATH`. So the origin of my problem was the same.