### PR TITLE
Use more portable function syntax; use mkdir -p

### DIFF
--- a/Tests/basic/runTest.sh
+++ b/Tests/basic/runTest.sh
@@ -7,7 +7,7 @@
 # Tests compilation error reporting.
 
 # Assert the equality of two strings.
-function assert() {
+assert() {
     echo "$1" >&2
     if [ "$1" != "$2" ]; then
         echo "Failed test $3";
@@ -16,11 +16,12 @@ function assert() {
 }
 
 ### SETUP ###
-mkdir working
+mkdir -p working
 cd working
 
 ### TEST A ###
 cp ../BasicTest.hs ../Main.hs .
+echo "attempting to make"
 ghc --make Main.hs -o basic 2> /dev/null
 OUTPUT_A=`./basic --dyre-debug`
 assert "$OUTPUT_A" "Basic Test Version 1.0 - 3" "A"

--- a/Tests/config-check/runTest.sh
+++ b/Tests/config-check/runTest.sh
@@ -4,7 +4,7 @@
 # upon relaunch, and restore the state again after.
 
 # Assert the equality of two strings.
-function assert() {
+assert() {
     echo "$1" >&2
     if [ "$1" != "$2" ]; then
         echo "Failed test $3";
@@ -12,7 +12,7 @@ function assert() {
     fi
 }
 
-mkdir working
+mkdir -p working
 cd working
 
 ### TEST A ###

--- a/Tests/recompile-relaunch/runTest.sh
+++ b/Tests/recompile-relaunch/runTest.sh
@@ -4,7 +4,7 @@
 # upon relaunch, and restore the state again after.
 
 # Assert the equality of two strings.
-function assert() {
+assert() {
     echo "$1" >&2
     if [ "$1" != "$2" ]; then
         echo "Failed test $3";
@@ -12,7 +12,7 @@ function assert() {
     fi
 }
 
-mkdir working
+mkdir -p working
 cd working
 
 ### TEST A ###


### PR DESCRIPTION
I got an error about "unexpected (" on ubuntu, this confused me so I
went to checkout out the advanced bash scripting guide, sure enough I
saw:

```
function function_name {
command...
}
or

function_name () {
command...
}

This second form will cheer the hearts of C programmers (and is more portable).
```

http://tldp.org/LDP/abs/html/functions.html

After fixing this error I got an error about the directory "working"
already existing. The -p flag will work whether it exists or not.
