### PR TITLE
Allow to use NIX_GHC next to HC env variable

### DIFF
--- a/Config/Dyre/Compile.hs
+++ b/Config/Dyre/Compile.hs
@@ -4,6 +4,7 @@ deals with error handling, and not the compilation itself /per se/.
 -}
 module Config.Dyre.Compile ( customCompile, getErrorPath, getErrorString ) where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent ( rtsSupportsBoundThreads )
 import Control.Monad (when)
 import Data.Maybe (fromMaybe)
@@ -64,7 +65,9 @@ customCompile params@Params{statusOut = output} = do
             then return $ Just stackYamlPath
             else return Nothing
 
-        hc <- fromMaybe "ghc" <$> lookupEnv "HC"
+        hc' <- lookupEnv "HC"
+        nix_ghc <- lookupEnv "NIX_GHC"
+        let hc = fromMaybe "ghc" (hc' <|> nix_ghc)
         ghcProc <- maybe (runProcess hc flags (Just cacheDir') Nothing
                               Nothing Nothing (Just errHandle))
                          (\stackYaml' -> runProcess "stack" ("ghc" : "--stack-yaml" : stackYaml' : "--" : flags)


### PR DESCRIPTION
Nix generates wrapper scripts for packages which ship their own sources
in order to compile them with dyre. Currently they fail to compile,
because dyre can't find the GHC binary (esp. not on NixOS which doesn't
follow the File System Hierarchy Standard).

This patch adds the `NIX_GHC` alternative to pick beside `HC` in order
to find the GHC compiler.

Fixes: https://github.com/willdonnelly/dyre/issues/42